### PR TITLE
fix: resolver errores de tipos en HU-002 y TypeScript CSS declaration

### DIFF
--- a/app/api/admin/shelter-requests/route.ts
+++ b/app/api/admin/shelter-requests/route.ts
@@ -69,7 +69,6 @@ export async function GET() {
             // Datos del albergue
             shelter: {
                 name: shelter.name,
-                nit: shelter.nit,
                 municipality: shelter.municipality,
                 address: shelter.address,
                 description: shelter.description || 'Sin descripción',

--- a/app/api/auth/request-shelter-account/route.ts
+++ b/app/api/auth/request-shelter-account/route.ts
@@ -90,7 +90,6 @@ export async function POST(request: Request) {
             const shelter = await tx.shelter.create({
                 data: {
                     name: validatedData.shelterName,
-                    nit: validatedData.shelterNit,
                     municipality: validatedData.shelterMunicipality,
                     address: validatedData.shelterAddress,
                     description: validatedData.shelterDescription,

--- a/global.d.ts
+++ b/global.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Declaración de tipos para módulos CSS
+ * Permite a TypeScript reconocer importaciones de archivos .css
+ */
+
+declare module '*.css' {
+  const content: {};
+  export default content;
+}
+
+declare module '*.scss' {
+  const content: {};
+  export default content;
+}
+
+declare module '*.sass' {
+  const content: {};
+  export default content;
+}

--- a/lib/validations/user.schema.ts
+++ b/lib/validations/user.schema.ts
@@ -111,15 +111,6 @@ export const shelterApplicationSchema = z.object({
     .min(3, 'Nombre del albergue requerido')
     .max(100, 'Nombre muy largo'),
 
-  shelterNit: z
-    .string()
-    .regex(
-      /^[0-9]{9}-[0-9]$/,
-      'NIT inválido. Formato esperado: 900123456-7 (9 dígitos + guion + dígito de verificación)'
-    )
-    .min(11, 'NIT debe tener 11 caracteres (ejemplo: 900123456-7)')
-    .max(11, 'NIT debe tener 11 caracteres (ejemplo: 900123456-7)'),
-
   shelterMunicipality: z.nativeEnum(Municipality, {
     message: 'Municipio donde opera el albergue es requerido'
   }),

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -79,7 +79,6 @@ model User {
 model Shelter {
   id                String       @id @default(auto()) @map("_id") @db.ObjectId
   name              String
-  nit               String       @unique  // NIT único del albergue (DANE)
   municipality      Municipality
   address           String
   description       String?


### PR DESCRIPTION
- Remover referencias al campo 'nit' que no existe en la rama actual
- Eliminar validación shelterNit del schema Zod
- Agregar global.d.ts para declarar tipos de módulos CSS
- Regenerar cliente de Prisma sin el campo nit
- Resolver error TS2322 en request-shelter-account route
- Mantener coherencia con la rama feat/hu-002-solicitud-cuenta-albergue