### PR TITLE
feat(dashboard): Implementa componente UnderConstruction y páginas placeholder

### DIFF
--- a/app/(dashboard)/shelter/metrics/page.tsx
+++ b/app/(dashboard)/shelter/metrics/page.tsx
@@ -2,11 +2,10 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth/auth-options";
 import { redirect } from "next/navigation";
 import { UserRole } from "@prisma/client";
-import { Button } from '@/components/ui/button';
+import UnderConstruction from "@/components/layout/under-construction";
 import Link from 'next/link';
 import { ArrowLeft } from 'lucide-react';
 import { prisma } from "@/lib/utils/db";
-import Image from 'next/image';
 
 /**
  * Resumen: Página placeholder para la gestión de pedidos del vendedor.
@@ -50,20 +49,7 @@ export default async function ShelterMetricsPage() {
             </Link>
             <h1 className="text-2xl font-bold">Métricas de Adopciones</h1>
             <p className="text-gray-500 dark:text-gray-400 mb-4">Panel de información de tus métricas de adopciones</p>
-            <div className="flex flex-col p-8 border rounded-lg bg-gray-50 items-center text-center justify-center">
-                <p className="text-lg text-gray-600">Esta sección está en desarrollo</p>
-                <p className="text-sm text-gray-400 mt-2 mb-10">Pronto podrás visualizar y gestionar tus métricas aquí</p>
-                <Image
-                    src='/images/under_construction.png'
-                    alt="En construcción..."
-                    width={350}
-                    height={350}
-                    className="object-cover pointer-events-none"
-                />
-                <Button asChild className="mt-6">
-                    <Link href="/shelter">Volver al Dashboard</Link>
-                </Button>
-            </div>
+            <UnderConstruction />
         </div>
     );
 }

--- a/app/(dashboard)/vendor/metrics/page.tsx
+++ b/app/(dashboard)/vendor/metrics/page.tsx
@@ -2,11 +2,10 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth/auth-options";
 import { redirect } from "next/navigation";
 import { UserRole } from "@prisma/client";
-import { Button } from '@/components/ui/button';
 import Link from 'next/link';
 import { ArrowLeft } from 'lucide-react';
 import { prisma } from "@/lib/utils/db";
-import Image from 'next/image';
+import UnderConstruction from "@/components/layout/under-construction";
 
 /**
  * Resumen: Página placeholder para la gestión de pedidos del vendedor.
@@ -50,20 +49,7 @@ export default async function VendorMetricsPage() {
             </Link>
             <h1 className="text-2xl font-bold">Métricas de Ventas</h1>
             <p className="text-gray-500 dark:text-gray-400 mb-4">Panel de información de tus métricas de productos</p>
-            <div className="flex flex-col p-8 border rounded-lg bg-gray-50 items-center text-center justify-center">
-                <p className="text-lg text-gray-600">Esta sección está en desarrollo</p>
-                <p className="text-sm text-gray-400 mt-2 mb-10">Pronto podrás visualizar y gestionar tus métricas aquí</p>
-                <Image
-                    src='/images/under_construction.png'
-                    alt="En construcción..."
-                    width={350}
-                    height={350}
-                    className="object-cover pointer-events-none"
-                />
-                <Button asChild className="mt-6">
-                    <Link href="/vendor">Volver al Dashboard</Link>
-                </Button>
-            </div>
+            <UnderConstruction />
         </div>
     );
 }

--- a/app/(dashboard)/vendor/orders/page.tsx
+++ b/app/(dashboard)/vendor/orders/page.tsx
@@ -2,11 +2,10 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth/auth-options";
 import { redirect } from "next/navigation";
 import { UserRole } from "@prisma/client";
-import { Button } from '@/components/ui/button';
 import Link from 'next/link';
 import { ArrowLeft } from 'lucide-react';
 import { prisma } from "@/lib/utils/db";
-import Image from 'next/image';
+import UnderConstruction from "@/components/layout/under-construction";
 
 
 /**
@@ -51,21 +50,7 @@ export default async function VendorOrdersPage() {
             </Link>
             <h1 className="text-2xl font-bold">Mis Pedidos</h1>
             <p className="text-gray-500 dark:text-gray-400 mb-4">Gestiona y visualiza tus órdenes de compra de tus productos</p>
-            <div className="flex flex-col p-8 border rounded-lg bg-gray-50 items-center text-center justify-center">
-                <p className="text-lg text-gray-600">Esta sección está en desarrollo</p>
-                <p className="text-sm text-gray-400 mt-2 mb-10">Pronto podrás visualizar y gestionar tus pedidos aquí</p>
-                <Image
-                    src='/images/under_construction.png'
-                    alt="En construcción..."
-                    width={350}
-                    height={350}
-                    className="object-cover pointer-events-none"
-                />
-
-                <Button asChild className="mt-6">
-                    <Link href="/vendor">Volver al Dashboard</Link>
-                </Button>
-            </div>
+            <UnderConstruction />
         </div>
     );
 }

--- a/components/layout/under-construction.tsx
+++ b/components/layout/under-construction.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { Construction } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { buttonVariants } from "@/components/ui/button";
+
+export default function UnderConstruction() {
+    const router = useRouter();
+
+    return (
+        <div className="flex flex-col items-center justify-center min-h-[60vh] py-12 px-4 text-center">
+            <div className="bg-orange-100 p-6 rounded-full mb-6 relative">
+                <div className="absolute inset-0 bg-orange-200 rounded-full animate-ping opacity-20"></div>
+                <Construction className="w-16 h-16 text-orange-600 relative z-10" />
+            </div>
+
+            <h2 className="text-3xl font-bold tracking-tight text-gray-900 mb-4">
+                Sitio en Construcción
+            </h2>
+
+            <p className="text-lg text-gray-600 max-w-md mx-auto mb-8">
+                Estamos construyendo algo increíble para ti y tus mascotas. Esta sección estará disponible muy pronto.
+            </p>
+
+            <button
+                onClick={() => router.back()}
+                className={buttonVariants({ variant: "default" })}
+            >
+                Regresar
+            </button>
+        </div>
+    );
+}


### PR DESCRIPTION
# Descripción

Este PR implementa páginas placeholder para las secciones en desarrollo del dashboard y añade un componente reutilizable UnderConstruction.

## Cambios realizados

- Se creó el componente UnderConstruction.
- Se añadieron páginas de 'En construcción' para:
  - Métricas de vendedor
  - Pedidos de vendedor
  - Métricas de refugio

## Criterios de aceptación

- [x] Linting pasa sin errores.
- [x] Tests pasan correctamente.