### PR TITLE
fix(api/user): Corrige validación para reenviar solicitud de vendedor y albergue tras denegación

### DIFF
--- a/app/api/user/request-shelter-account/route.ts
+++ b/app/api/user/request-shelter-account/route.ts
@@ -47,25 +47,32 @@ export async function POST(request: Request) {
         //  3. (Paso eliminado) - userEmail verificado via session
 
 
-        //  4. Verificar si el usuario actual ya tiene una solicitud de albergue pendiente
-        const existingShelterRequest = await prisma.shelter.findFirst({
+        //  4. Verificar si el usuario actual ya tiene una solicitud de albergue pendiente o aprobada
+        const existingShelterRequest = await prisma.shelter.findUnique({
             where: {
                 userId: session.user.id,
-                verified: false,
             },
         });
 
         if (existingShelterRequest) {
-            return NextResponse.json(
-                {
-                    error: 'Ya tienes una solicitud de albergue pendiente',
-                    code: 'PENDING_REQUEST_EXISTS',
-                    message: 'Tu solicitud está siendo revisada por un administrador',
-                    shelterName: existingShelterRequest.name,
-                    createdAt: existingShelterRequest.createdAt,
-                },
-                { status: 409 }
-            );
+            if (existingShelterRequest.verified) {
+                return NextResponse.json(
+                    { error: 'Ya eres un albergue verificado', code: 'ALREADY_SHELTER' },
+                    { status: 409 }
+                );
+            }
+            if (existingShelterRequest.rejectionReason === null) {
+                return NextResponse.json(
+                    {
+                        error: 'Ya tienes una solicitud de albergue pendiente',
+                        code: 'PENDING_REQUEST_EXISTS',
+                        message: 'Tu solicitud está siendo revisada por un administrador',
+                        shelterName: existingShelterRequest.name,
+                        createdAt: existingShelterRequest.createdAt,
+                    },
+                    { status: 409 }
+                );
+            }
         }
 
         //  5. Hashear la contraseña
@@ -92,9 +99,10 @@ export async function POST(request: Request) {
                 },
             });
 
-            // Crear registro de albergue (sin verificar)
-            const shelter = await tx.shelter.create({
-                data: {
+            // Crear o actualizar registro de albergue (sin verificar)
+            const shelter = await tx.shelter.upsert({
+                where: { userId: user.id },
+                create: {
                     name: validatedData.shelterName,
                     nit: validatedData.shelterNit,
                     municipality: validatedData.shelterMunicipality,
@@ -108,6 +116,20 @@ export async function POST(request: Request) {
                     verified: false, // Pendiente de aprobación
                     userId: user.id,
                 },
+                update: {
+                    name: validatedData.shelterName,
+                    nit: validatedData.shelterNit,
+                    municipality: validatedData.shelterMunicipality,
+                    address: validatedData.shelterAddress,
+                    description: validatedData.shelterDescription,
+                    contactWhatsApp: validatedData.contactWhatsApp,
+                    contactInstagram: validatedData.contactInstagram,
+                    latitude: coords?.lat || null,
+                    longitude: coords?.lng || null,
+                    geocodedAt: coords ? new Date() : null,
+                    verified: false, // Pendiente de aprobación
+                    rejectionReason: null, // Limpiar motivo de rechazo previo
+                }
             });
 
             return { user, shelter };

--- a/app/api/user/request-vendor-account/route.ts
+++ b/app/api/user/request-vendor-account/route.ts
@@ -58,14 +58,16 @@ export async function POST(request: Request) {
                     { status: 409 }
                 );
             }
-            return NextResponse.json(
-                {
-                    error: 'Ya tienes una solicitud de vendedor pendiente',
-                    code: 'PENDING_REQUEST_EXISTS',
-                    message: 'Tu solicitud está siendo revisada por un administrador',
-                },
-                { status: 409 }
-            );
+            if (existingVendorRequest.rejectionReason === null) {
+                return NextResponse.json(
+                    {
+                        error: 'Ya tienes una solicitud de vendedor pendiente',
+                        code: 'PENDING_REQUEST_EXISTS',
+                        message: 'Tu solicitud está siendo revisada por un administrador',
+                    },
+                    { status: 409 }
+                );
+            }
         }
 
         //  4. Hashear la contraseña (si se envió una nueva, aunque el form la pide, 
@@ -92,9 +94,10 @@ export async function POST(request: Request) {
                 },
             });
 
-            // Crear registro de vendedor (sin verificar)
-            const vendor = await tx.vendor.create({
-                data: {
+            // Crear o actualizar registro de vendedor (sin verificar)
+            const vendor = await tx.vendor.upsert({
+                where: { userId: user.id },
+                create: {
                     businessName: validatedData.businessName,
                     businessPhone: validatedData.businessPhone,
                     description: validatedData.businessDescription,
@@ -103,6 +106,15 @@ export async function POST(request: Request) {
                     verified: false, // Pendiente de aprobación
                     userId: user.id,
                 },
+                update: {
+                    businessName: validatedData.businessName,
+                    businessPhone: validatedData.businessPhone,
+                    description: validatedData.businessDescription,
+                    municipality: validatedData.businessMunicipality,
+                    address: validatedData.businessAddress,
+                    verified: false, // Pendiente de aprobación
+                    rejectionReason: null, // Limpiar motivo de rechazo previo
+                }
             });
 
             return { user, vendor };


### PR DESCRIPTION
## 🎯 Qué hace este PR

Corrige la validación al crear/reenviar solicitudes de cuenta de albergue y vendedor. Anteriormente, el sistema bloqueaba cualquier solicitud nueva si existía un registro previo no verificado, incluyendo los que habían sido denegados. Se ha ajustado la validación para permitir solicitudes cuando la anterior posee un motivo de rechazo (`rejectionReason`). Además, se cambió la operación a `upsert` para evitar errores de clave única duplicada de MongoDB, limpiando el motivo de rechazo previo y retornando la solicitud al estado pendiente (`verified: false`).

## 🔗 Issue

Closes #139

---

## 📋 Metadata

**Status:**

- [ ] 📋 Todo
- [ ] 🔄 En Progreso
- [ ] 👀 En Revisión
- [x] ✅ Finalizado

**Tipo:**

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 💥 Breaking change
- [ ] 📚 Docs
- [ ] ⚡ Performance
- [ ] ♻️ Refactor
- [ ] 🧪 Tests
- [ ] 🔧 Build/CI

**Size (Story Points):**

- [ ] XS
- [x] S
- [ ] M
- [ ] L
- [ ] XL
- [ ] XXL

**Priority:**

- [ ] P0 - Crítico
- [x] P1 - Alto
- [ ] P2 - Medio
- [ ] P3 - Bajo

---

## ✅ Checklist

**Code:**

- [x] Sigue style guide del proyecto
- [x] Self-reviewed
- [x] Sin warnings
- [x] Comentado código complejo

**Tests:**

- [ ] Tests agregados/actualizados
- [ ] Todos los tests pasan
- [ ] Coverage mantenido/mejorado

**Docs:**

- [ ] Docs actualizados (si aplica)
- [ ] CHANGELOG actualizado (si aplica)
- [x] Comments en código

**QA:**

- [x] Probado localmente
- [ ] Funciona en dev/staging
- [x] Edge cases cubiertos

## 🔄 Cambios

**Archivos principales:**

- `app/api/user/request-shelter-account/route.ts`
- `app/api/user/request-vendor-account/route.ts`

**Breaking changes:**

- [x] No
- [ ] Sí: [explicar]

## 🧪 Testing

**Tests realizados:**

- [ ] Unit
- [ ] Integration
- [ ] E2E
- [x] Manual

**Casos probados:**

1. ✅ Envío inicial de solicitud de albergue/vendedor se crea correctamente en estado pendiente.
2. ✅ Envío duplicado mientras la solicitud está pendiente es correctamente rechazado con error de proceso existente.
3. ✅ Envío de solicitud tras rechazo previo actualiza el registro, remueve el `rejectionReason` y lo vuelve a dejar pendiente.
4. ✅ Intento de reenvío para usuarios ya verificados es rechazado.

## 📸 Screenshots/Logs

No aplica.

## 📊 Performance

- [x] Sin impacto
- [ ] Mejora: [métrica]
- [ ] Degradación: [justificar]

## 🚀 Deploy

- [x] Deploy directo
- [ ] Requiere migración: [especificar]
- [ ] Requiere config: [especificar]
- [ ] Feature flag: [nombre]

## 📝 Notas

**Para reviewers:**

Se usó la función `upsert` de Prisma apuntando al índice único de `userId` para sobreescribir la solicitud previamente denegada sin violar la restricción única en MongoDB.

**Próximos pasos:**

---

**Preview deploy:**
**Staging:**
